### PR TITLE
Making the Project Name be rguilayout consistently

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -29,9 +29,10 @@
 PLATFORM              ?= PLATFORM_DESKTOP
 
 # Define project variables
-PROJECT_NAME          ?= rtoolname
+PROJECT_NAME          ?= rguilayout
 PROJECT_VERSION       ?= 1.0
 PROJECT_BUILD_PATH    ?= .
+
 
 RAYLIB_PATH           ?= C:/GitHub/raylib
 RAYLIB_INCLUDE_PATH   ?= $(RAYLIB_PATH)/src
@@ -303,7 +304,7 @@ endif
 # Define source code files required
 #------------------------------------------------------------------------------------------------
 PROJECT_SOURCE_FILES ?= \
-    rtoolname.c \
+    $(PROJECT_NAME).c \
     external/tinyfiledialogs.c
 
 # Define all object files from source files


### PR DESCRIPTION
Fixed what looked like placeholder / default naming for the main .c file.