### PR TITLE
Fix bugs when scaling controls

### DIFF
--- a/src/rguilayout.c
+++ b/src/rguilayout.c
@@ -1287,6 +1287,7 @@ int main(int argc, char *argv[])
 
                         if (rec.width < SCALE_BOX_CORNER_SIZE) rec.width = SCALE_BOX_CORNER_SIZE;
                         if (rec.height < SCALE_BOX_CORNER_SIZE) rec.height = SCALE_BOX_CORNER_SIZE;
+                        if (layout->controls[selectedControl].type == GUI_WINDOWBOX && rec.height < RAYGUI_WINDOWBOX_STATUSBAR_HEIGHT*2) rec.height = RAYGUI_WINDOWBOX_STATUSBAR_HEIGHT*2;
 
                         // NOTE: We must consider anchor offset!
                         if (layout->controls[selectedControl].ap->id > 0)

--- a/src/rguilayout.c
+++ b/src/rguilayout.c
@@ -2580,6 +2580,7 @@ int main(int argc, char *argv[])
                     if (!dragMoveMode && resizeMode) colControl = colControlSelectedResize;
 
                     Rectangle selectedRec = layout->controls[selectedControl].rec;
+                    float reportedRecHeight = selectedRec.height;
                     if (layout->controls[selectedControl].type == GUI_WINDOWBOX) selectedRec.height = RAYGUI_WINDOWBOX_STATUSBAR_HEIGHT;  // Defined inside raygui.h!
                     else if (layout->controls[selectedControl].type == GUI_GROUPBOX)
                     {
@@ -2616,14 +2617,14 @@ int main(int argc, char *argv[])
                                 (int)(layout->controls[selectedControl].rec.x),
                                 (int)(layout->controls[selectedControl].rec.y),
                                 (int)selectedRec.width,
-                                (int)selectedRec.height),
+                                (int)reportedRecHeight),
                                 selectedRec.x, selectedRec.y - 30, 20, colPositionText);
                         }
                         else DrawText(TextFormat("[%i, %i, %i, %i]",
                             (int)(selectedRec.x - (int)layout->refWindow.x),
                             (int)(selectedRec.y - (int)layout->refWindow.y),
                             (int)selectedRec.width,
-                            (int)selectedRec.height),
+                            (int)reportedRecHeight),
                             selectedRec.x, selectedRec.y - 30, 20, colPositionText);
                     }
                     else
@@ -2632,7 +2633,7 @@ int main(int argc, char *argv[])
                             (int)(selectedRec.x - (int)layout->refWindow.x),
                             (int)(selectedRec.y - (int)layout->refWindow.y),
                             (int)selectedRec.width,
-                            (int)selectedRec.height),
+                            (int)reportedRecHeight),
                             selectedRec.x, selectedRec.y - 30, 20, colPositionText);
                     }
 
@@ -2721,6 +2722,7 @@ int main(int argc, char *argv[])
                 {
                     // Draw focused rectangle
                     Rectangle focusedRec = layout->controls[focusedControl].rec;
+                    float reportedRecHeight = focusedRec.height;
 
                     if (layout->controls[focusedControl].type == GUI_WINDOWBOX) focusedRec.height = RAYGUI_WINDOWBOX_STATUSBAR_HEIGHT;  // Defined inside raygui.h!
                     else if (layout->controls[focusedControl].type == GUI_GROUPBOX)
@@ -2759,14 +2761,14 @@ int main(int argc, char *argv[])
                                 (int)(layout->controls[focusedControl].rec.x),
                                 (int)(layout->controls[focusedControl].rec.y),
                                 (int)focusedRec.width,
-                                (int)focusedRec.height),
+                                (int)reportedRecHeight),
                                 focusedRec.x, focusedRec.y - 30, 20, colPositionText);
                         }
                         else DrawText(TextFormat("[%i, %i, %i, %i]",
                             (int)(focusedRec.x - (int)layout->refWindow.x),
                             (int)(focusedRec.y - (int)layout->refWindow.y),
                             (int)focusedRec.width,
-                            (int)focusedRec.height),
+                            (int)reportedRecHeight),
                             focusedRec.x, focusedRec.y - 30, 20, colPositionText);
                     }
                     else
@@ -2775,7 +2777,7 @@ int main(int argc, char *argv[])
                             (int)(focusedRec.x - (int)layout->refWindow.x),
                             (int)(focusedRec.y - (int)layout->refWindow.y),
                             (int)focusedRec.width,
-                            (int)focusedRec.height),
+                            (int)reportedRecHeight),
                             focusedRec.x, focusedRec.y - 30, 20, colPositionText);
                     }
                 }


### PR DESCRIPTION
Changes:
- Fix `GroupBox` reported control size being stuck at 20
- Fix `WindowBox` reported control size being stuck at 24
- `WindowBox` selection now has a minimum size of 48, as the control will not go shorter causing a mismatch between the desired height and actual height
