### PR TITLE
Fix issue #22: Incorrect behavior of Line element and Define text as const

### DIFF
--- a/src/codegen.h
+++ b/src/codegen.h
@@ -601,6 +601,7 @@ static void WriteConstText(char *toolstr, int *pos, GuiLayout *layout, GuiLayout
             case GUI_LISTVIEW:
             case GUI_DUMMYREC:
             case GUI_STATUSBAR:
+            case GUI_LINE:
             {
                 TextAppend(toolstr, TextFormat("const char *%sText = \"%s\";", layout->controls[i].name, layout->controls[i].text), pos);
                 if (config.fullComments)

--- a/src/codegen.h
+++ b/src/codegen.h
@@ -608,6 +608,9 @@ static void WriteConstText(char *toolstr, int *pos, GuiLayout *layout, GuiLayout
             case GUI_SCROLLPANEL:
             case GUI_COLORPICKER:
             {
+                // Skip constant text for elements with no text
+                if (layout->controls[i].text[0] == '\0') continue;
+
                 TextAppend(toolstr, TextFormat("const char *%sText = \"%s\";", layout->controls[i].name, layout->controls[i].text), pos);
                 if (config.fullComments)
                 {
@@ -1085,7 +1088,12 @@ static char *GetControlTextParam(GuiLayoutControl control, bool defineText)
     static char text[512];
     memset(text, 0, 512);
 
-    if (defineText) strcpy(text, TextFormat("%sText", control.name));
+    if (defineText) 
+    {
+        // Skip constant text for elements with no text
+        if (control.text[0] == '\0') strcpy(text, "NULL");
+        else strcpy(text, TextFormat("%sText", control.name));
+    }
     else 
     {
         // NOTE: control.text will never be NULL

--- a/src/codegen.h
+++ b/src/codegen.h
@@ -602,6 +602,11 @@ static void WriteConstText(char *toolstr, int *pos, GuiLayout *layout, GuiLayout
             case GUI_DUMMYREC:
             case GUI_STATUSBAR:
             case GUI_LINE:
+            case GUI_PANEL:
+            case GUI_VALUEBOX:
+            case GUI_SPINNER:
+            case GUI_SCROLLPANEL:
+            case GUI_COLORPICKER:
             {
                 TextAppend(toolstr, TextFormat("const char *%sText = \"%s\";", layout->controls[i].name, layout->controls[i].text), pos);
                 if (config.fullComments)


### PR DESCRIPTION
Fixed the issue described at #22 where code generation wouldn't generate constant strings for line elements when `Define text as const ` option was checked, in the issue I also mention the possibility of other elements maybe having the same issue, those elements are now fixed too.
The original issue mentioned a possible improvement so elements with empty text don't generate an empty const string, actually that improvement is necessary for some elements because when the code generated something like `const char *SomeControlName = "";` when an empty string like that was passed to some elements could cause certain rendering problems with some parts of the control. 
Now when the code gen finds an element whose text is "" it doesn't generates a const string and passes NULL as text parameter to the element drawing function (this applies to all controls i belive)